### PR TITLE
Workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/chadsr/marktplaats-scraper/security/code-scanning/3](https://github.com/chadsr/marktplaats-scraper/security/code-scanning/3)

To fix the issue, add an explicit `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves actions like checking out code, installing dependencies, running tests, and uploading coverage reports, the `contents: read` permission is sufficient for most jobs. For the `test` job, which uploads coverage to Codecov, additional permissions for `secrets` may be required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, we will add permissions at the root level to simplify the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
