### PR TITLE
Workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install Python 3
@@ -34,6 +36,9 @@ jobs:
   test:
     strategy:
       fail-fast: true
+    permissions:
+      contents: read
+      actions: write
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.12"]
@@ -84,6 +89,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   security:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install Python 3


### PR DESCRIPTION
Potential fix for [https://github.com/chadsr/marktplaats-scraper/security/code-scanning/1](https://github.com/chadsr/marktplaats-scraper/security/code-scanning/1)

To fix the issue, we need to add explicit `permissions` blocks to the workflow. The permissions should be set at the job level for each job (`lint`, `test`, and `security`) to ensure they have the least privileges required to complete their tasks. For example:
- The `lint` job only needs read access to the repository contents.
- The `test` job requires read access to contents and write access for uploading coverage reports.
- The `security` job only needs read access to contents.

The `permissions` block should be added directly under each job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
