### PR TITLE
Workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 on:
   pull_request:
     paths:
@@ -32,6 +34,9 @@ jobs:
         env:
           RUFF_OUTPUT_FORMAT: github
   test:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/chadsr/marktplaats-scraper/security/code-scanning/2](https://github.com/chadsr/marktplaats-scraper/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves actions like checking out code, installing dependencies, running tests, and uploading coverage reports, the `contents: read` permission is sufficient for most jobs. For the `test` job, which uploads coverage to Codecov, we also need to include `contents: read` and possibly `pull-requests: write` if it interacts with pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions for specific tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
